### PR TITLE
Bump base image to 4.6.2 from 4.5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM saucelabs/sauce-connect:4.5.4
+FROM saucelabs/sauce-connect:4.6.2
 
 LABEL version="1.0.0"
 LABEL repository="http://github.com/saucelabs/sauce-connect-action"


### PR DESCRIPTION
This fixes https://github.com/saucelabs/sauce-connect-action/issues/3